### PR TITLE
adjust documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Be advised that these tests usually have a longer execution time (~20 mins to an
 First, we need to build the KEVM definition for this Foundry property test suite:
 
 ```sh
-kevm foundry-kompile --require lemmas.k --module-import DEMO-LEMMAS
+kevm foundry-kompile --require lemmas.k --module-import ERC20:DEMO-LEMMAS
 ```
 
 When you are working, you may need to rebuild the definition in various ways.


### PR DESCRIPTION
I was trying to run foundry-demo following the documentation:

`kevm foundry-kompile --require lemmas.k --module-import DEMO-LEMMAS`


It throws error
![image](https://github.com/runtimeverification/foundry-demo/assets/19416734/902be078-efb9-4752-a47c-fea89ffcd294)
